### PR TITLE
feat: Add Weather Dashboard with City Search, Suggestions, History & Theme Toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "@reduxjs/toolkit": "^2.8.2",
         "dotenv": "^17.2.0",
@@ -1021,6 +1022,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.2.0.tgz",
+      "integrity": "sha512-gRCspp3pfjHQyTmSOmYw7kUQTd9Udpdan4R8EnZvqPeoAtHnPzkvjBrBqzKaoAbbBp5bGF7BcD18zZJh4nwu0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.2.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "@reduxjs/toolkit": "^2.8.2",
     "dotenv": "^17.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,16 @@
-function App() {
-  return <div>hello</div>;
-}
+import { Container } from "@mui/material";
+import Header from "./components/Header";
+import WeatherDashboard from "./features/weather/components/WeatherDashboard";
+
+const App = () => {
+  return (
+    <>
+      <Header />
+      <Container maxWidth="sm" sx={{ mt: 2 }}>
+        <WeatherDashboard />
+      </Container>
+    </>
+  );
+};
 
 export default App;

--- a/src/components/CustomAutoComplete.tsx
+++ b/src/components/CustomAutoComplete.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Autocomplete, CircularProgress, TextField } from "@mui/material";
+
+import type {
+  AutocompleteChangeReason,
+  AutocompleteChangeDetails,
+} from "@mui/material/Autocomplete";
+
+interface CustomAutoCompleteProps<T> {
+  options: T[];
+  freeSolo?: boolean;
+  loading?: boolean;
+  label?: string;
+  value?: T | null;
+  fullWidth?: boolean;
+  getOptionLabel: (option: T | string) => string;
+  onInputChange: (event: React.SyntheticEvent, value: string) => void;
+  onChange: (
+    event: React.SyntheticEvent,
+    value: string | T | null,
+    reason: AutocompleteChangeReason,
+    details?: AutocompleteChangeDetails<string | T>
+  ) => void;
+}
+
+function CustomAutoComplete<T>(props: CustomAutoCompleteProps<T>) {
+  const {
+    label,
+    options,
+    freeSolo = false,
+    loading = false,
+    fullWidth = true,
+    value,
+    getOptionLabel,
+    onInputChange,
+    onChange,
+  } = props;
+
+  return (
+    <Autocomplete
+      freeSolo={freeSolo}
+      options={options}
+      getOptionLabel={getOptionLabel}
+      loading={loading}
+      onInputChange={onInputChange}
+      onChange={onChange}
+      value={value ?? null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label || "Asynchronous"}
+          fullWidth={fullWidth}
+          slotProps={{
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <React.Fragment>
+                  {loading ? (
+                    <CircularProgress color="inherit" size={20} />
+                  ) : null}
+                  {params.InputProps.endAdornment}
+                </React.Fragment>
+              ),
+            },
+          }}
+        />
+      )}
+    />
+  );
+}
+
+export default CustomAutoComplete;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  AppBar,
+  Box,
+  Toolbar,
+  Typography,
+  IconButton,
+  useTheme,
+} from "@mui/material";
+import { Brightness4, Brightness7 } from "@mui/icons-material";
+import { useColorMode } from "../context/ThemeContext";
+
+const Header: React.FC = () => {
+  const theme = useTheme();
+  const colorMode = useColorMode();
+
+  return (
+    <AppBar position="static" color="primary">
+      <Toolbar sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Typography
+          variant="h6"
+          noWrap
+          component="div"
+          sx={{ display: { xs: "block" }, fontWeight: 600 }}
+        >
+          Outfit Planner
+        </Typography>
+
+        <Box>
+          <IconButton onClick={colorMode.toggleColorMode} color="inherit">
+            {theme.palette.mode === "dark" ? <Brightness7 /> : <Brightness4 />}
+          </IconButton>
+        </Box>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useMemo, useState, useEffect } from "react";
+import { createTheme, ThemeProvider, type PaletteMode } from "@mui/material";
+import CssBaseline from "@mui/material/CssBaseline";
+const THEME_STORAGE_KEY = "ofit-theme";
+type CustomThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+const ColorModeContext = createContext({
+  toggleColorMode: () => {},
+  mode: "light" as PaletteMode,
+});
+
+export function useColorMode() {
+  const context = React.useContext(ColorModeContext);
+  if (!context) {
+    throw new Error("useColorMode must be used within a CustomThemeProvider");
+  }
+  return context;
+}
+
+export const CustomThemeProvider: React.FC<CustomThemeProviderProps> = ({
+  children,
+}) => {
+  const [mode, setMode] = useState<PaletteMode>("light");
+
+  useEffect(() => {
+    const storedMode = localStorage.getItem(THEME_STORAGE_KEY) as PaletteMode;
+    if (storedMode) setMode(storedMode);
+  }, []);
+
+  const colorMode = useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode((prevMode) => {
+          const newMode = prevMode === "light" ? "dark" : "light";
+          localStorage.setItem(THEME_STORAGE_KEY, newMode);
+          return newMode;
+        });
+      },
+      mode,
+    }),
+    [mode]
+  );
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+        },
+      }),
+    [mode]
+  );
+
+  return (
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ColorModeContext.Provider>
+  );
+};

--- a/src/features/weather/components/SearchHistory.tsx
+++ b/src/features/weather/components/SearchHistory.tsx
@@ -1,0 +1,28 @@
+import { Box, Typography, List, ListItemButton } from "@mui/material";
+
+type SearchHistoryProps = {
+  history: string[];
+  onSelect: (input: string) => void;
+};
+
+export default function SearchHistory({
+  history,
+  onSelect,
+}: SearchHistoryProps) {
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant="h6">Search History</Typography>
+      <List>
+        {history.map((item, i) => (
+          <ListItemButton
+            sx={{ border: "1px solid lightgray", borderRadius: 1, mb: 1 }}
+            key={i}
+            onClick={() => onSelect(item)}
+          >
+            {item}
+          </ListItemButton>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/features/weather/components/SearchHistory.tsx
+++ b/src/features/weather/components/SearchHistory.tsx
@@ -1,8 +1,9 @@
 import { Box, Typography, List, ListItemButton } from "@mui/material";
+import type { CitySuggestion } from "../weatherApi";
 
 type SearchHistoryProps = {
-  history: string[];
-  onSelect: (input: string) => void;
+  history: CitySuggestion[];
+  onSelect: (val: CitySuggestion) => void;
 };
 
 export default function SearchHistory({
@@ -13,15 +14,21 @@ export default function SearchHistory({
     <Box sx={{ mt: 4 }}>
       <Typography variant="h6">Search History</Typography>
       <List>
-        {history.map((item, i) => (
-          <ListItemButton
-            sx={{ border: "1px solid lightgray", borderRadius: 1, mb: 1 }}
-            key={i}
-            onClick={() => onSelect(item)}
-          >
-            {item}
-          </ListItemButton>
-        ))}
+        {history.length > 0 ? (
+          history.map((item) => (
+            <ListItemButton
+              sx={{ border: "1px solid lightgray", borderRadius: 1, mb: 1 }}
+              key={item.id}
+              onClick={() => onSelect(item)}
+            >
+              {item.name}, {item.country}
+            </ListItemButton>
+          ))
+        ) : (
+          <Typography variant="body2" color="textSecondary">
+            No search history available.
+          </Typography>
+        )}
       </List>
     </Box>
   );

--- a/src/features/weather/components/WeatherCard.tsx
+++ b/src/features/weather/components/WeatherCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, Grid, Typography } from "@mui/material";
-import { type WeatherResponse } from "../weatherApi";
+import { type CitySuggestion, type WeatherResponse } from "../weatherApi";
 import {
   getWeatherCondition,
   getWeatherSuggestion,
@@ -8,19 +8,19 @@ import { WetherCardItem } from "./WeatherCardItem";
 
 type WeatherCardProps = {
   data: WeatherResponse;
-  city: string;
+  city: CitySuggestion;
 };
 
 export const WeatherCard = ({ data, city }: WeatherCardProps) => {
   const { weatherCode, humidity, temperature, windSpeed } = data;
-  const suggestion = getWeatherSuggestion(weatherCode);
-  const weatherCondition = getWeatherCondition(weatherCode);
+  const suggestion = getWeatherSuggestion(weatherCode); // Get suggestion based on weather code
+  const weatherCondition = getWeatherCondition(weatherCode); // Get weather condition based on weather code
 
   return (
     <Card sx={{ mt: 2 }}>
       <CardContent>
         <Typography variant="h6" mb={2}>
-          {city}
+          {city.name}, {city.country}
         </Typography>
 
         <Grid container spacing={2}>

--- a/src/features/weather/components/WeatherDashboard.tsx
+++ b/src/features/weather/components/WeatherDashboard.tsx
@@ -1,0 +1,93 @@
+import { Alert, CircularProgress, Box } from "@mui/material";
+import CustomAutoComplete from "../../../components/CustomAutoComplete";
+import {
+  useGetWeatherByCoordsQuery,
+  useLazyGetCitySuggestionsQuery,
+  type CitySuggestion,
+} from "../weatherApi";
+import SearchHistory from "./SearchHistory";
+import { WeatherCard } from "./WeatherCard";
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useState, useEffect } from "react";
+import { useColorMode } from "../../../context/ThemeContext";
+import { useAppDispatch, useAppSelector } from "../../../hooks/reduxHooks";
+import { useDebounce } from "../../../hooks/useDebounce";
+import { addToHistory } from "../weatherSlice";
+
+export default function WeatherDashboard() {
+  const dispatch = useAppDispatch();
+  const { mode: colorMode } = useColorMode();
+  const history = useAppSelector((state) => state.weather.history);
+
+  const [input, setInput] = useState("");
+  const [selectedCity, setSelectedCity] = useState<CitySuggestion | null>(null);
+
+  const debouncedInput = useDebounce(input, 300);
+  const [
+    triggerSuggestions,
+    { data: suggestions = [], isFetching: isFetchingSuggestions },
+  ] = useLazyGetCitySuggestionsQuery();
+
+  // Fetch city suggestions when input changes
+  // Only trigger if input length is 3 or more characters
+  useEffect(() => {
+    if (debouncedInput.length >= 3) {
+      triggerSuggestions(debouncedInput);
+    }
+  }, [debouncedInput, triggerSuggestions]);
+
+  // Fetch weather data based on selected city coordinates
+  // If no city is selected, skip the query
+  const {
+    data: weatherData,
+    isFetching: isFetchingWeather,
+    error,
+  } = useGetWeatherByCoordsQuery(selectedCity || skipToken);
+
+  // Automatically add selected city to history if not already present
+  useEffect(() => {
+    if (selectedCity && !history.some((c) => c.id === selectedCity.id)) {
+      dispatch(addToHistory(selectedCity));
+    }
+  }, [selectedCity, history, dispatch]);
+
+  return (
+    <>
+      <CustomAutoComplete<CitySuggestion>
+        label="Search City"
+        options={suggestions}
+        loading={isFetchingSuggestions}
+        onInputChange={(_, value) => setInput(value)}
+        onChange={(_, value) => setSelectedCity(value as CitySuggestion)}
+        getOptionLabel={(option) => {
+          const op = option as CitySuggestion;
+          return `${op.name}, ${op.country}`;
+        }}
+      />
+
+      {isFetchingWeather && (
+        <Box display="flex" mt={2} justifyContent="center">
+          <CircularProgress size={24} />
+        </Box>
+      )}
+
+      {error && (
+        <Alert
+          severity="error"
+          variant={colorMode === "dark" ? "outlined" : "standard"}
+          sx={{
+            mt: 2,
+          }}
+        >
+          City not found or API error.
+        </Alert>
+      )}
+
+      {weatherData && selectedCity && (
+        <WeatherCard data={weatherData} city={selectedCity} />
+      )}
+
+      <SearchHistory history={history} onSelect={setSelectedCity} />
+    </>
+  );
+}

--- a/src/features/weather/weatherApi.ts
+++ b/src/features/weather/weatherApi.ts
@@ -10,6 +10,7 @@ export interface WeatherResponse {
 }
 
 export interface CitySuggestion {
+  id: number | string;
   name: string;
   country: string;
   latitude: number;
@@ -29,6 +30,7 @@ export const weatherApi = createApi({
       transformResponse: (response: any): CitySuggestion[] => {
         return (
           response.results?.map((r: any) => ({
+            id: r.id,
             name: r.name,
             country: r.country,
             latitude: r.latitude,

--- a/src/features/weather/weatherSlice.ts
+++ b/src/features/weather/weatherSlice.ts
@@ -1,7 +1,8 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { CitySuggestion } from "./weatherApi";
 
 interface WeatherState {
-  history: string[];
+  history: CitySuggestion[];
 }
 
 const initialState: WeatherState = {
@@ -12,12 +13,13 @@ const weatherSlice = createSlice({
   name: "weather",
   initialState,
   reducers: {
-    addToHistory(state, action: PayloadAction<string>) {
+    addToHistory(state, action: PayloadAction<CitySuggestion>) {
       const city = action.payload;
-      state.history = [city, ...state.history.filter((c) => c !== city)].slice(
-        0,
-        5
-      );
+      // Add the city to the history, ensuring no duplicates and limiting to 5 items
+      state.history = [
+        city,
+        ...state.history.filter((c) => c.id !== city.id),
+      ].slice(0, 5);
     },
   },
 });

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+// This hook debounces a value by a specified delay
+// It returns the debounced value after the delay has passed
 export const useDebounce = <T>(value: T, delay: number): T => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,18 +2,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { store } from "./store.ts";
+import { CustomThemeProvider } from "./context/ThemeContext.tsx";
 import App from "./App.tsx";
-import { createTheme, CssBaseline, ThemeProvider } from "@mui/material";
-
-const theme = createTheme(); // Default MUI theme
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Provider store={store}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
+      <CustomThemeProvider>
         <App />
-      </ThemeProvider>
+      </CustomThemeProvider>
     </Provider>
   </StrictMode>
 );


### PR DESCRIPTION

## Summary

- Added city search input with debounced auto-suggestions.
- Integrated [Open-Meteo](https://open-meteo.com/) API for:
  - City geocoding suggestions
  - Current weather forecast
- Displays:
  - Temperature
  - Wind speed
  - Humidity
  - Weather condition
  - Suggestion
- API requests are cached using RTK Query (`keepUnusedDataFor`).

###  Search History

- Maintains the last 5 searched cities (in-memory via Redux).
- Allows clicking a history item to re-trigger weather search (will load cached result).

###  Theme Toggle

- Added dark/light mode support using MUI theme.
- Theme switcher placed in the header.
