### PR TITLE
feat: Add colorful weather icons and minor UI improvements to WeatherCard

### DIFF
--- a/src/components/CustomAutoComplete.tsx
+++ b/src/components/CustomAutoComplete.tsx
@@ -39,6 +39,7 @@ function CustomAutoComplete<T>(props: CustomAutoCompleteProps<T>) {
   return (
     <Autocomplete
       freeSolo={freeSolo}
+      autoHighlight
       options={options}
       getOptionLabel={getOptionLabel}
       loading={loading}

--- a/src/features/weather/components/WeatherCard.tsx
+++ b/src/features/weather/components/WeatherCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, Grid, Typography } from "@mui/material";
-import { type CitySuggestion, type WeatherResponse } from "../weatherApi";
+import { type WeatherResponse } from "../weatherApi";
 import {
   getWeatherCondition,
   getWeatherSuggestion,
@@ -8,11 +8,10 @@ import { WetherCardItem } from "./WeatherCardItem";
 
 type WeatherCardProps = {
   data: WeatherResponse;
-  city: CitySuggestion;
 };
 
-export const WeatherCard = ({ data, city }: WeatherCardProps) => {
-  const { weatherCode, humidity, temperature, windSpeed } = data;
+export const WeatherCard = ({ data }: WeatherCardProps) => {
+  const { city, weatherCode, humidity, temperature, windSpeed } = data;
   const suggestion = getWeatherSuggestion(weatherCode); // Get suggestion based on weather code
   const weatherCondition = getWeatherCondition(weatherCode); // Get weather condition based on weather code
 
@@ -20,7 +19,7 @@ export const WeatherCard = ({ data, city }: WeatherCardProps) => {
     <Card sx={{ mt: 2 }}>
       <CardContent>
         <Typography variant="h6" mb={2}>
-          {city.name}, {city.country}
+          {city}
         </Typography>
 
         <Grid container spacing={2}>

--- a/src/features/weather/components/WeatherCard.tsx
+++ b/src/features/weather/components/WeatherCard.tsx
@@ -5,9 +5,30 @@ import {
   getWeatherSuggestion,
 } from "../utils/weatherCondition";
 import { WetherCardItem } from "./WeatherCardItem";
+import {
+  AcUnit,
+  Cloud,
+  Grain,
+  Thunderstorm,
+  WbSunny,
+} from "@mui/icons-material";
 
 type WeatherCardProps = {
   data: WeatherResponse;
+};
+
+const getWeatherIcon = (intCode: number) => {
+  if ([0, 1].includes(intCode))
+    return <WbSunny fontSize="large" sx={{ color: "#fbc02d" }} />; // yellow
+  if ([2, 3].includes(intCode))
+    return <Cloud fontSize="large" sx={{ color: "#90a4ae" }} />; // gray-blue
+  if ([45, 48].includes(intCode))
+    return <AcUnit fontSize="large" sx={{ color: "#4fc3f7" }} />; // icy blue
+  if ([51, 53, 55, 61, 63, 65, 80, 81, 82].includes(intCode))
+    return <Grain fontSize="large" sx={{ color: "#2196f3" }} />; // rainy blue
+  if ([95, 96, 99].includes(intCode))
+    return <Thunderstorm fontSize="large" sx={{ color: "#673ab7" }} />; // purple storm
+  return <Cloud fontSize="large" sx={{ color: "#90a4ae" }} />;
 };
 
 export const WeatherCard = ({ data }: WeatherCardProps) => {
@@ -18,6 +39,7 @@ export const WeatherCard = ({ data }: WeatherCardProps) => {
   return (
     <Card sx={{ mt: 2 }}>
       <CardContent>
+        {getWeatherIcon(weatherCode)}
         <Typography variant="h6" mb={2}>
           {city}
         </Typography>

--- a/src/features/weather/components/WeatherDashboard.tsx
+++ b/src/features/weather/components/WeatherDashboard.tsx
@@ -48,8 +48,24 @@ export default function WeatherDashboard() {
   useEffect(() => {
     if (selectedCity && !history.some((c) => c.id === selectedCity.id)) {
       dispatch(addToHistory(selectedCity));
+      setSelectedCity(null); // Reset selected city after adding to history
     }
   }, [selectedCity, history, dispatch]);
+
+  const handleOnChange = (
+    _: React.SyntheticEvent,
+    value: string | CitySuggestion | null
+  ) => {
+    if (value) {
+      setSelectedCity(value as CitySuggestion);
+    }
+  };
+
+  const handleInputChange = (_: React.SyntheticEvent, value: string) => {
+    if (value) {
+      setInput(value);
+    }
+  };
 
   return (
     <>
@@ -57,8 +73,8 @@ export default function WeatherDashboard() {
         label="Search City"
         options={suggestions}
         loading={isFetchingSuggestions}
-        onInputChange={(_, value) => setInput(value)}
-        onChange={(_, value) => setSelectedCity(value as CitySuggestion)}
+        onInputChange={handleInputChange}
+        onChange={handleOnChange}
         getOptionLabel={(option) => {
           const op = option as CitySuggestion;
           return `${op.name}, ${op.country}`;
@@ -83,9 +99,7 @@ export default function WeatherDashboard() {
         </Alert>
       )}
 
-      {weatherData && selectedCity && (
-        <WeatherCard data={weatherData} city={selectedCity} />
-      )}
+      {weatherData && <WeatherCard data={weatherData} />}
 
       <SearchHistory history={history} onSelect={setSelectedCity} />
     </>

--- a/src/features/weather/weatherApi.ts
+++ b/src/features/weather/weatherApi.ts
@@ -40,10 +40,7 @@ export const weatherApi = createApi({
       },
     }),
 
-    getWeatherByCoords: builder.query<
-      WeatherResponse,
-      { latitude: number; longitude: number; name: string }
-    >({
+    getWeatherByCoords: builder.query<WeatherResponse, CitySuggestion>({
       query: ({ latitude, longitude }) => ({
         url: `${WEATHER_API_URL}/forecast`,
         params: {
@@ -60,7 +57,7 @@ export const weatherApi = createApi({
         const hourly = response.hourly;
 
         return {
-          city: arg.name,
+          city: `${arg.name}, ${arg.country}`,
           temperature: current.temperature,
           windSpeed: current.windspeed,
           humidity: hourly.relative_humidity_2m[0],


### PR DESCRIPTION
## Summary

### 🎨 Colorful Weather Icons
- Integrated condition-based icons using **@mui/icons-material**
- Icons reflect Open-Meteo's `weathercode`:
  - ☀️ `WbSunny` (Clear sky) - yellow
  - ☁️ `Cloud` (Cloudy) - soft gray-blue
  - ❄️ `AcUnit` (Fog/Frost) - icy blue
  - 🌧️ `Grain` (Rain) - blue
  - ⛈️ `Thunderstorm` (Storm) - purple

### 🔧 UI Tweaks
- Icons now appear next to the location title (`Weather in City`)
