### PR TITLE
fix: reset selected city after adding to history in WeatherDashboard not required

### DIFF
--- a/src/features/weather/components/WeatherDashboard.tsx
+++ b/src/features/weather/components/WeatherDashboard.tsx
@@ -48,7 +48,6 @@ export default function WeatherDashboard() {
   useEffect(() => {
     if (selectedCity && !history.some((c) => c.id === selectedCity.id)) {
       dispatch(addToHistory(selectedCity));
-      setSelectedCity(null); // Reset selected city after adding to history
     }
   }, [selectedCity, history, dispatch]);
 


### PR DESCRIPTION
reset selected city after adding to history in WeatherDashboard not required